### PR TITLE
Fix version file URL property

### DIFF
--- a/EasyISP.version
+++ b/EasyISP.version
@@ -1,6 +1,6 @@
 {
     "NAME": "EasyISP",
-    "URL": "https://github.com/Tempus-superest/EasyISP",
+    "URL": "https://raw.githubusercontent.com/Tempus-superest/EasyISP/main/EasyISP.version",
     "DOWNLOAD": "https://github.com/Tempus-superest/EasyISP/releases/tag/1.0.0",
     "VERSION": {
         "MAJOR": 1,


### PR DESCRIPTION
Hi @Tempus-superest, the `URL` property of a version file is meant to point to an online copy of the version file itself, in case there were changes in compatibility since the release was made, not the repo. This PR fixes it.
Cheers!

Noticed while working on KSP-CKAN/NetKAN#9983.
