### PR TITLE
Use lightweight git tag in release workflow and bump version to v1.2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,10 @@ jobs:
       - name: Create and push tag
         if: steps.tag_check.outputs.tag_exists != 'true'
         run: |
-          # Create an annotated tag locally so the release references a real pushed tag.
+          # Create a lightweight tag locally so it does not require git user identity on CI.
           tag="${{ steps.version.outputs.TAG }}"
           # Ensure the tag is created only once on the release automation path.
-          git tag -a "$tag" -m "Release $tag"
+          git tag "$tag"
           # Push the tag before creating the GitHub release to avoid untagged URLs.
           git push origin "$tag"
 

--- a/EasyISP.version
+++ b/EasyISP.version
@@ -1,11 +1,11 @@
 {
     "NAME": "EasyISP",
     "URL": "https://raw.githubusercontent.com/Tempus-superest/EasyISP/main/EasyISP.version",
-    "DOWNLOAD": "https://github.com/Tempus-superest/EasyISP/releases/tag/v1.2.2",
+    "DOWNLOAD": "https://github.com/Tempus-superest/EasyISP/releases/tag/v1.2.3",
     "VERSION": {
         "MAJOR": 1,
         "MINOR": 2,
-        "PATCH": 2
+        "PATCH": 3
     },
     "KSP_VERSION": {
         "MAJOR": 1,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EasyISP - A Mod for Kerbal Space Program
 
-Current Version - [v1.2.2](https://github.com/Tempus-superest/EasyISP/releases/tag/v1.2.2)
+Current Version - [v1.2.3](https://github.com/Tempus-superest/EasyISP/releases/tag/v1.2.3)
 
 **EasyISP** is a **KSP** add-on that increases engine efficiency so your rockets can go farther on the same amount of fuel. In **KSP**, higher **ISP** means you get more delta-v from a single tank. **EasyISP** applies **ModuleManager** patches that edit the **atmosphereCurve** on each targeted **Engine module** (including **ModuleEngines** and **ModuleEnginesFX**), applying a predictable global **ISP** multiplier while keeping each engine’s curve shape and relative behavior intact. The default **ISP** multiplier applied by **EasyISP** is `2`.
 


### PR DESCRIPTION
### Motivation
- Fix CI failure caused by `git tag -a` requiring `user.name`/`user.email` on GitHub runners. 
- Preserve the release ordering that pushes the tag before calling `gh release create` so the release URL points to a real tag. 
- Bump the project version to `v1.2.3` so metadata and docs match the intended release.

### Description
- Replace annotated tag creation `git tag -a "$tag" -m "Release $tag"` with a lightweight tag `git tag "$tag"` in `.github/workflows/release.yml`, and add a comment explaining the CI identity rationale. 
- Keep the existing `git push origin "$tag"` step before running `gh release create` and retain the existing tag-exists and retry logic. 
- Update `EasyISP.version` `DOWNLOAD` URL to point to `/releases/tag/v1.2.3` and set `PATCH` to `3`. 
- Update `README.md` current version link/text to `v1.2.3` and preserve `--generate-notes`, validation, and asset upload behavior.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698038817f4c8321b362e522a7d5f8c9)